### PR TITLE
fix: no report file

### DIFF
--- a/configured_oper.go
+++ b/configured_oper.go
@@ -32,6 +32,9 @@ type configuredOper struct {
 
 // getFile by checking if it exists and querying user about how to treat the file
 func getFile(s string) *os.File {
+  if s == "" {
+    return nil
+  }
 	f, err := os.Create(s)
 	if err != nil {
 		panic(fmt.Sprintf("not good: %v", err))

--- a/configured_oper_test.go
+++ b/configured_oper_test.go
@@ -171,7 +171,7 @@ func Test_results(t *testing.T) {
 func Test_configuredOper_New(t *testing.T) {
 	t.Run("it should return incrementConfigError if increment is true and no args contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(0, 0, args, true, output.HIDDEN, "testing", output.HIDDEN, nil, true)
+		_, gotErr := New(0, 0, args, true, output.HIDDEN, "testing", output.HIDDEN, "", true)
 		if gotErr == nil {
 			t.Fatal("expected to get error, got nil")
 		}
@@ -190,7 +190,7 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should't return an error if increment is true and argument contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "INC"}
-		_, gotErr := New(0, -1, args, true, output.HIDDEN, "testing", output.HIDDEN, nil, true)
+		_, gotErr := New(0, -1, args, true, output.HIDDEN, "testing", output.HIDDEN, "", true)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}


### PR DESCRIPTION
When running the command without the flag `-reportFile`, I got the following error:

```
$ repeater -n 2 echo foobar
panic: not good: open : no such file or directory

goroutine 1 [running]:
main.getFile({0x0?, 0xc000104b90?})
        /home/l-lin/perso/repeater/configured_oper.go:37 +0x79
main.New(0x2, 0x1, {0xc0000140d0?, 0xc000104c58?, 0x2}, 0x1, 0x2, {0x4ded55, 0x12}, 0x2, ...)
        /home/l-lin/perso/repeater/configured_oper.go:86 +0x25a
main.main()
        /home/l-lin/perso/repeater/main.go:55 +0x405
exit status 2
```

It's because the `reportFile` variable has empty string by default, hence the `os.Create` returns an error.