### PR TITLE
feat: replace increment placeholder in arguments + lenient increment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go install github.com/baalimago/repeater@latest
 
 ## Usage
 Repeater is designed to perform repetitive tasks with slight modification.
-Personally I've used it to CRUD state in paralell and fill login event logs as fast as I have network sockets.
+Personally I've used it to CRUD state in parallel and fill login event logs as fast as I have network sockets.
 It can probably also be used as a ghetto benchmarking tool.
 
 ```bash
@@ -25,9 +25,9 @@ repeater -n 100 -w 10 -reportFile ./run_output -output REPORT_FILE -progress BOT
 repeater -n 100 -w 10 curl wadiwaudbwadiubwada
 
 # This will print "this is increment: 1\nthis is increment: 2\n..."
-repeater -n 100 -increment echo "this is increment: " INC
+repeater -n 100 -increment echo "this is increment: INC"
 
-# Show all avaliable flags 
+# Show all available flags
 repeater -h
 ```
 

--- a/configured_oper.go
+++ b/configured_oper.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
-	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +16,8 @@ import (
 	"github.com/baalimago/repeater/internal/output"
 	"github.com/baalimago/repeater/pkg/filetools"
 )
+
+const incrementPlaceholder = "INC"
 
 type configuredOper struct {
 	am             int
@@ -44,7 +46,7 @@ type incrementConfigError struct {
 }
 
 func (ice incrementConfigError) Error() string {
-	return fmt.Sprintf("increment is true, but args: %v, does not contain string 'INC'", ice.args)
+	return fmt.Sprintf("increment is true, but args: %v, does not contain string '%s'", ice.args, incrementPlaceholder)
 }
 
 func New(am, workers int,
@@ -63,7 +65,7 @@ func New(am, workers int,
 		return configuredOper{}, fmt.Errorf("progress: %v, or output: %v, requires a report file, but none is specified", pMode, oMode)
 	}
 
-	if increment && !slices.Contains(args, "INC") {
+	if increment && !containsIncrementPlaceholder(args) {
 		return configuredOper{
 			color: *colorFlag,
 		}, incrementConfigError{args: args}
@@ -155,8 +157,8 @@ func (c configuredOper) replaceIncrement(args []string, i int) []string {
 	if c.increment {
 		var newArgs []string
 		for _, arg := range args {
-			if arg == "INC" {
-				arg = fmt.Sprintf("%v", i)
+			if strings.Contains(arg, incrementPlaceholder) {
+				arg = strings.ReplaceAll(arg, incrementPlaceholder, strconv.Itoa(i))
 			}
 			newArgs = append(newArgs, arg)
 		}
@@ -269,4 +271,13 @@ WORK_DELEGATOR:
 	ret.totalTime = time.Since(confOperStart)
 
 	return ret
+}
+
+func containsIncrementPlaceholder(args []string) bool {
+	for _, arg := range args {
+		if strings.Contains(arg, incrementPlaceholder) {
+			return true
+		}
+	}
+	return false
 }

--- a/configured_oper_test.go
+++ b/configured_oper_test.go
@@ -188,9 +188,17 @@ func Test_configuredOper_New(t *testing.T) {
 		}
 	})
 
-	t.Run("it should't return an error if increment is true and argument contains 'INC'", func(t *testing.T) {
+	t.Run("it should not return an error if increment is true and one argument is 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "INC"}
 		_, gotErr := New(0, -1, args, true, output.HIDDEN, "testing", output.HIDDEN, nil, true)
+		if gotErr != nil {
+			t.Fatalf("expected nil, got: %v", gotErr)
+		}
+	})
+
+	t.Run("it should not return an error if increment is true and one argument contains 'INC'", func(t *testing.T) {
+		args := []string{"test", "abc", "another-argument/INC"}
+		_, gotErr := New(0, -1, args, true, output.HIDDEN, "testing", output.HIDDEN, "", true)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}


### PR DESCRIPTION
Instead of a single `INC` argument to replace the placeholder, we should be able to replace all argument contents.

More often, the increment placeholder is included in one argument content of the command to repeat, e.g.

```bash
curl https://httpbin.org/base64/INC
```

(Side note: it would be nice to have this placeholder replaced by something that can be customized, for example, randomized UUID, a line from a file,... but that's another story)