### PR TITLE
feat: outputOnSuccess flag which hides successful output on false

### DIFF
--- a/configured_oper.go
+++ b/configured_oper.go
@@ -36,6 +36,7 @@ type configuredOper struct {
 	startedAt             time.Time
 	rollingAverageRuntime time.Duration
 	totalRuntime          time.Duration
+	hideOutputOnSuccess   bool
 }
 
 type userQuitError string
@@ -64,6 +65,7 @@ func New(am, workers int,
 	increment bool,
 	resultFlag string,
 	retryOnFail bool,
+	hideOutputOnSuccess bool,
 ) (configuredOper, error) {
 	shouldHaveReportFile := pMode == output.BOTH || pMode == output.FILE ||
 		oMode == output.BOTH || oMode == output.FILE
@@ -81,19 +83,20 @@ func New(am, workers int,
 	}
 
 	c := configuredOper{
-		am:             am,
-		workers:        workers,
-		args:           args,
-		progress:       pMode,
-		progressFormat: progressFormat,
-		output:         oMode,
-		outputFileMu:   &sync.Mutex{},
-		increment:      increment,
-		amSuccess:      0,
-		workerWg:       &sync.WaitGroup{},
-		amIdleWorkers:  workers,
-		workPlanMu:     &sync.Mutex{},
-		retryOnFail:    retryOnFail,
+		am:                  am,
+		workers:             workers,
+		args:                args,
+		progress:            pMode,
+		progressFormat:      progressFormat,
+		output:              oMode,
+		outputFileMu:        &sync.Mutex{},
+		increment:           increment,
+		amSuccess:           0,
+		workerWg:            &sync.WaitGroup{},
+		amIdleWorkers:       workers,
+		workPlanMu:          &sync.Mutex{},
+		retryOnFail:         retryOnFail,
+		hideOutputOnSuccess: hideOutputOnSuccess,
 	}
 
 	c.workerWg.Add(workers)
@@ -164,6 +167,11 @@ report file mode: %v`, c.am, c.args, c.increment, c.workers, c.progress, c.progr
 }
 
 func (c *configuredOper) writeOutput(res *Result) {
+	// If output on success is hidden and the outcome
+	// is not an error (a success), then return
+	if c.hideOutputOnSuccess && !res.IsError {
+		return
+	}
 	switch c.output {
 	case output.STDOUT:
 		fmt.Fprintf(os.Stdout, "%v", res.Output)

--- a/configured_oper_test.go
+++ b/configured_oper_test.go
@@ -187,10 +187,99 @@ func Test_results(t *testing.T) {
 	})
 }
 
+func Test_configuredOper_writeOutput_hideOutputOnSuccess(t *testing.T) {
+	// Matrix validating that when hideOutputOnSuccess is true, output is only
+	// written on errors, while successful runs are suppressed. When
+	// hideOutputOnSuccess is false (the zero value), output is always written.
+	testCases := []struct {
+		name                string
+		hideOutputOnSuccess bool
+		isError             bool
+		wantWritten         bool
+	}{
+		{"suppress success when hideOutputOnSuccess=true", true, false, false},
+		{"emit error even when hideOutputOnSuccess=true", true, true, true},
+		{"emit success when hideOutputOnSuccess=false", false, false, true},
+		{"emit error when hideOutputOnSuccess=false", false, true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testFile := testboil.CreateTestFile(t, "tFile")
+			wantOutput := "some-output"
+			c := configuredOper{
+				output:              output.FILE,
+				outputFile:          testFile,
+				hideOutputOnSuccess: tc.hideOutputOnSuccess,
+			}
+			res := Result{Output: wantOutput, IsError: tc.isError}
+
+			c.writeOutput(&res)
+
+			testFileName := testFile.Name()
+			testFile.Close()
+			got, err := checkReportFileContent(testFileName)
+			if err != nil {
+				t.Fatalf("failed to get report file: %v", err)
+			}
+
+			if tc.wantWritten && got != wantOutput {
+				t.Fatalf("expected output %q to be written, got: %q", wantOutput, got)
+			}
+			if !tc.wantWritten && got != "" {
+				t.Fatalf("expected no output to be written, got: %q", got)
+			}
+		})
+	}
+}
+
+// Test_configuredOper_run_onlyOutputOnError validates the same behavior
+// end-to-end through run: with hideOutputOnSuccess=true, a successful command
+// produces no output while a failing command does.
+func Test_configuredOper_run_onlyOutputOnError(t *testing.T) {
+	runTest := func(t *testing.T, args []string, wantOutput bool) {
+		testFile := testboil.CreateTestFile(t, "tFile")
+		c := configuredOper{
+			am:                  1,
+			args:                args,
+			progress:            output.HIDDEN,
+			output:              output.FILE,
+			outputFile:          testFile,
+			hideOutputOnSuccess: true,
+			amIdleWorkers:       1,
+			workPlanMu:          &sync.Mutex{},
+			workerWg:            &sync.WaitGroup{},
+		}
+		c.workerWg.Add(1)
+
+		c.run(context.Background())
+		testFileName := testFile.Name()
+		testFile.Close()
+		got, err := checkReportFileContent(testFileName)
+		if err != nil {
+			t.Fatalf("failed to get report file: %v", err)
+		}
+		if wantOutput && got == "" {
+			t.Fatalf("expected output on error, got empty string")
+		}
+		if !wantOutput && got != "" {
+			t.Fatalf("expected no output on success, got: %q", got)
+		}
+	}
+
+	t.Run("it should not output on success", func(t *testing.T) {
+		runTest(t, []string{"printf", "success-output"}, false)
+	})
+	t.Run("it should output on error", func(t *testing.T) {
+		// 'false' exits non-zero, so doWork flags the result as an error.
+		runTest(t, []string{"false"}, true)
+	})
+}
+
 func Test_configuredOper_New(t *testing.T) {
 	t.Run("it should return incrementConfigError if increment is true and no args contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
 		if gotErr == nil {
 			t.Fatal("expected to get error, got nil")
 		}
@@ -209,7 +298,7 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if increment is true and one argument is 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "INC"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
@@ -217,7 +306,7 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if increment is true and one argument contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "another-argument/INC"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
@@ -227,7 +316,7 @@ func Test_configuredOper_New(t *testing.T) {
 		am := 1
 		workers := 2
 		args := []string{"test", "abc"}
-		_, gotErr := New(am, workers, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false)
+		_, gotErr := New(am, workers, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
 		if gotErr == nil {
 			t.Fatal("expected to get error, got nil")
 		}
@@ -241,16 +330,31 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if the number of workers is lower than the number of times to repeat the command", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(2, 1, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false)
+		_, gotErr := New(2, 1, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
 	})
 	t.Run("it should not return an error if the number of workers is equal to the number of times to repeat the command", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(2, 2, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false)
+		_, gotErr := New(2, 2, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
+		}
+	})
+
+	// Guards against the hideOutputOnSuccess argument being accepted but never
+	// wired into the returned struct (a dead flag).
+	t.Run("it should wire the hideOutputOnSuccess argument into the returned struct", func(t *testing.T) {
+		for _, want := range []bool{true, false} {
+			args := []string{"true"}
+			c, gotErr := New(1, 1, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, want)
+			if gotErr != nil {
+				t.Fatalf("expected nil, got: %v", gotErr)
+			}
+			if c.hideOutputOnSuccess != want {
+				t.Fatalf("expected hideOutputOnSuccess: %v, got: %v", want, c.hideOutputOnSuccess)
+			}
 		}
 	})
 }

--- a/configured_oper_work.go
+++ b/configured_oper_work.go
@@ -157,7 +157,8 @@ func (c *configuredOper) runResultCollector(ctx context.Context, resultChan chan
 			fmt.Sprintf(c.progressFormat,
 				amSuccess, amFails, c.am,
 				c.startedAt.Format(time.RFC3339), timeLeft.Seconds(), estCompletion.Format(time.RFC3339)),
-			progressStreams)
+			progressStreams,
+		)
 		return amSuccess
 	}
 

--- a/main.go
+++ b/main.go
@@ -18,19 +18,20 @@ import (
 const DefaultProgressFormat = "\rProgress: (Success/Fail/Requested Am)(%v/%v/%v), Start at: %v, Remaining: %.1fs, Est. done at: %v"
 
 var (
-	amRunsFlag         = flag.Int("n", 1, "Amount of times you wish to repeat the command.")
-	verboseFlag        = flag.Bool("v", false, "Set to display the configured operation before running")
-	workersFlag        = flag.Int("w", 1, "Set the amout of workers to repeat the command with. Having more than 1 makes execution paralell. Expect performance diminishing returns when approaching CPU threads.")
-	colorFlag          = flag.Bool("nocolor", false, "Set to true to disable ansi-colored output")
-	progressFlag       = flag.String("progress", "STDOUT", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
-	progressFormatFlag = flag.String("progressFormat", DefaultProgressFormat, "Set the format for the output where 1st arg is the iteration and 2d arg is the amount of runs, 3d total, 4th start, 5th countdown, 6th est completion time.")
-	outputFlag         = flag.String("output", "HIDDEN", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
-	fileFlag           = flag.String("file", "", "Path to the file where the report will be saved, configure file conflicts automatically with 'fileMode'")
-	fileModeFlag       = flag.String("fileMode", "", "Configure how the report file should be treated. If a file exists, and this option isn't set, user will be queried. Options are: ['t'runcate, 'a'ppend] ")
-	statisticsFlag     = flag.Bool("statistics", true, "Set to true if you don't wish to see statistics of the repeated command.")
-	incrementFlag      = flag.Bool("increment", false, "Set to true and add an argument 'INC', to have 'INC' be replaced with the iteration. If increment == true && 'INC' is not set, repeater will panic.")
-	resultFlag         = flag.String("result", "", "Set this to some filename and get a json-formated output of all the performed tasks. This output is the basis of the statistics.")
-	retryOnFailFlag    = flag.Bool("retryOnFail", false, "Set to true to retry failed commands, effectively making repeate run until all commands are successful.")
+	amRunsFlag          = flag.Int("n", 1, "Amount of times you wish to repeat the command.")
+	verboseFlag         = flag.Bool("v", false, "Set to display the configured operation before running")
+	workersFlag         = flag.Int("w", 1, "Set the amout of workers to repeat the command with. Having more than 1 makes execution paralell. Expect performance diminishing returns when approaching CPU threads.")
+	colorFlag           = flag.Bool("nocolor", false, "Set to true to disable ansi-colored output")
+	progressFlag        = flag.String("progress", "STDOUT", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
+	progressFormatFlag  = flag.String("progressFormat", DefaultProgressFormat, "Set the format for the output where 1st arg is the iteration and 2d arg is the amount of runs, 3d total, 4th start, 5th countdown, 6th est completion time.")
+	outputFlag          = flag.String("output", "HIDDEN", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
+	fileFlag            = flag.String("file", "", "Path to the file where the report will be saved, configure file conflicts automatically with 'fileMode'")
+	fileModeFlag        = flag.String("fileMode", "", "Configure how the report file should be treated. If a file exists, and this option isn't set, user will be queried. Options are: ['t'runcate, 'a'ppend] ")
+	statisticsFlag      = flag.Bool("statistics", true, "Set to true if you don't wish to see statistics of the repeated command.")
+	incrementFlag       = flag.Bool("increment", false, "Set to true and add an argument 'INC', to have 'INC' be replaced with the iteration. If increment == true && 'INC' is not set, repeater will panic.")
+	resultFlag          = flag.String("result", "", "Set this to some filename and get a json-formated output of all the performed tasks. This output is the basis of the statistics.")
+	retryOnFailFlag     = flag.Bool("retryOnFail", false, "Set to true to retry failed commands, effectively making repeate run until all commands are successful.")
+	outputOnSuccessFlag = flag.Bool("outputOnSuccess", true, "Set to false if you don't wish to see output on success")
 )
 
 func main() {
@@ -53,7 +54,9 @@ func main() {
 		*fileModeFlag,
 		*incrementFlag,
 		*resultFlag,
-		*retryOnFailFlag)
+		*retryOnFailFlag,
+		!*outputOnSuccessFlag,
+	)
 
 	if *verboseFlag {
 		fmt.Printf("Operation:\n%v\n------\n", &c)


### PR DESCRIPTION
It does pretty much exactly what title suggests. I often run things repeatedly to bait flaky errors. This way
I don't get the noise from the successes, only get the failures. Very helpful!