### PR TITLE
feat: Context cancel summaries + output format v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+You're working on a project called `repeater`.
+
+## Always read
+
+- `./main.go` — this contains CLI flags and the primary execution flow.
+- `./go.mod` — this shows which libraries are used; do not add additional third-party libraries unless explicitly requested.
+- `./README.md` — this contains the project usage model, examples, and expected operator-facing behavior.
+- `./configured_oper.go` — this defines the main runtime configuration and core invariants.
+- `./configured_oper_work.go` — this contains worker orchestration, cancellation, and result collection logic.
+- `./statistics.go` — this defines result aggregation and user-visible statistics output.
+
+## Way of work
+
+- Always write tests first, implementation second.
+- When fixing a bug, validate the issue with a test, then fix the implementation.
+- Prefer minimal diffs over broad refactors.
+- Preserve CLI behavior unless the task explicitly changes it.
+- For concurrency or cancellation changes, verify both correctness and shutdown behavior.
+
+## Validation
+
+Before you're done, ensure that these pass:
+
+- `go test ./... -race -cover -timeout=10s`
+- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
+- `go run mvdan.cc/gofumpt@latest -w .`
+
+ALWAYS TEST WITH TIMEOUT. Otherwise you may deadlock debugging efforts.

--- a/configured_oper.go
+++ b/configured_oper.go
@@ -37,6 +37,7 @@ type configuredOper struct {
 	rollingAverageRuntime time.Duration
 	totalRuntime          time.Duration
 	hideOutputOnSuccess   bool
+	wasCancelled          bool
 }
 
 type userQuitError string

--- a/configured_oper.go
+++ b/configured_oper.go
@@ -21,6 +21,7 @@ type configuredOper struct {
 	progress              output.Mode
 	progressFormat        string
 	output                output.Mode
+	outputFormat          string
 	outputFile            *os.File
 	outputFileMu          *sync.Mutex
 	outputFileMode        string
@@ -48,6 +49,11 @@ func (uqe userQuitError) Error() string {
 
 const UserQuitError userQuitError = "user quit"
 
+const (
+	outputFormatV1 = "v1"
+	outputFormatV2 = "v2"
+)
+
 type incrementConfigError struct {
 	args []string
 }
@@ -61,6 +67,7 @@ func New(am, workers int,
 	pMode output.Mode,
 	progressFormat string,
 	oMode output.Mode,
+	outFormat string,
 	outputFile string,
 	outputFileMode string,
 	increment bool,
@@ -90,6 +97,7 @@ func New(am, workers int,
 		progress:            pMode,
 		progressFormat:      progressFormat,
 		output:              oMode,
+		outputFormat:        outFormat,
 		outputFileMu:        &sync.Mutex{},
 		increment:           increment,
 		amSuccess:           0,
@@ -173,15 +181,30 @@ func (c *configuredOper) writeOutput(res *Result) {
 	if c.hideOutputOnSuccess && !res.IsError {
 		return
 	}
+	formatted := res.Output
+	if c.outputFormat == outputFormatV2 {
+		formatted = formatOutputV2(res)
+	}
 	switch c.output {
 	case output.STDOUT:
-		fmt.Fprintf(os.Stdout, "%v", res.Output)
+		fmt.Fprintf(os.Stdout, "%v", formatted)
 	case output.FILE:
-		fmt.Fprintf(c.outputFile, "%v", res.Output)
+		fmt.Fprintf(c.outputFile, "%v", formatted)
 	case output.BOTH:
-		fmt.Fprintf(os.Stdout, "%v", res.Output)
-		fmt.Fprintf(c.outputFile, "%v", res.Output)
+		fmt.Fprintf(os.Stdout, "%v", formatted)
+		fmt.Fprintf(c.outputFile, "%v", formatted)
 	}
+}
+
+func formatOutputV2(res *Result) string {
+	formatEvents := func(label string, events []OutputEvent) string {
+		out := fmt.Sprintf("%s:\n", label)
+		for _, event := range events {
+			out += fmt.Sprintf("%s: %s", event.At.Format(time.RFC3339), event.Text)
+		}
+		return out
+	}
+	return fmt.Sprintf("%s---\n%s", formatEvents("stdout", res.Stdout), formatEvents("stderr", res.Stderr))
 }
 
 func (c *configuredOper) setupProgressStreams() []io.Writer {

--- a/configured_oper_test.go
+++ b/configured_oper_test.go
@@ -398,6 +398,45 @@ func Test_configuredOper_run_onlyOutputOnError(t *testing.T) {
 	})
 }
 
+func Test_configuredOper_run_cancellation(t *testing.T) {
+	t.Run("it should cancel in-flight command and report cancelled stats", func(t *testing.T) {
+		c := configuredOper{
+			am:            1,
+			args:          []string{"bash", "-lc", "sleep 5"},
+			workPlanMu:    &sync.Mutex{},
+			workerWg:      &sync.WaitGroup{},
+			amIdleWorkers: 1,
+		}
+		c.workerWg.Add(1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(100*time.Millisecond, cancel)
+
+		started := time.Now()
+		stats := c.run(ctx)
+		elapsed := time.Since(started)
+
+		if elapsed >= 3*time.Second {
+			t.Fatalf("expected cancellation to stop promptly, got runtime %v", elapsed)
+		}
+		if stats.amDone < 0 || stats.amDone > 1 {
+			t.Fatalf("expected completed count in [0,1], got %d", stats.amDone)
+		}
+		if len(stats.Results) > 0 && !stats.Results[0].IsError {
+			if !stats.Results[0].IsCancelled {
+				t.Fatal("expected cancelled command result to be marked as cancelled")
+			}
+		}
+		if !strings.Contains(stats.String(), fmt.Sprintf("completed: %d", stats.amDone)) {
+			t.Fatalf("expected statistics string to report completed count, got: %s", stats.String())
+		}
+		stats.cancelled = true
+		if !strings.Contains(stats.String(), "(cancelled)") {
+			t.Fatalf("expected statistics string to mark cancellation, got: %s", stats.String())
+		}
+	})
+}
+
 func Test_configuredOper_New(t *testing.T) {
 	t.Run("it should return incrementConfigError if increment is true and no args contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc"}

--- a/configured_oper_test.go
+++ b/configured_oper_test.go
@@ -355,6 +355,62 @@ func Test_configuredOper_writeOutput_hideOutputOnSuccess(t *testing.T) {
 	}
 }
 
+func Test_configuredOper_writeOutput_formatV2(t *testing.T) {
+	testFile := testboil.CreateTestFile(t, "tFile")
+	c := configuredOper{
+		output:       output.FILE,
+		outputFile:   testFile,
+		outputFormat: outputFormatV2,
+	}
+	res := Result{
+		Stdout: []OutputEvent{{At: time.Unix(1, 0).UTC(), Text: "hello\n"}},
+		Stderr: []OutputEvent{{At: time.Unix(2, 0).UTC(), Text: "boom\n"}},
+	}
+
+	c.writeOutput(&res)
+
+	testFileName := testFile.Name()
+	testFile.Close()
+	got, err := checkReportFileContent(testFileName)
+	if err != nil {
+		t.Fatalf("failed to get report file: %v", err)
+	}
+	if !strings.Contains(got, "stdout:\n1970-01-01T00:00:01Z: hello\n") {
+		t.Fatalf("expected stdout timeline in v2 output, got: %q", got)
+	}
+	if !strings.Contains(got, "---\nstderr:\n1970-01-01T00:00:02Z: boom\n") {
+		t.Fatalf("expected stderr timeline in v2 output, got: %q", got)
+	}
+}
+
+func Test_outputRecorder_capturesTimestampedStreams(t *testing.T) {
+	res := Result{}
+	stdout := outputRecorder{res: &res, stream: stdoutStream}
+	stderr := outputRecorder{res: &res, stream: stderrStream}
+
+	_, _ = stdout.Write([]byte("hello\n"))
+	_, _ = stderr.Write([]byte("boom\n"))
+
+	if len(res.Stdout) != 1 {
+		t.Fatalf("expected one stdout event, got %d", len(res.Stdout))
+	}
+	if len(res.Stderr) != 1 {
+		t.Fatalf("expected one stderr event, got %d", len(res.Stderr))
+	}
+	if res.Stdout[0].Text != "hello\n" {
+		t.Fatalf("unexpected stdout text: %q", res.Stdout[0].Text)
+	}
+	if res.Stderr[0].Text != "boom\n" {
+		t.Fatalf("unexpected stderr text: %q", res.Stderr[0].Text)
+	}
+	if res.Stdout[0].At.IsZero() || res.Stderr[0].At.IsZero() {
+		t.Fatal("expected timestamps to be recorded")
+	}
+	if !strings.Contains(res.Output, "hello\n") || !strings.Contains(res.Output, "boom\n") {
+		t.Fatalf("expected combined output to include both streams, got: %q", res.Output)
+	}
+}
+
 // Test_configuredOper_run_onlyOutputOnError validates the same behavior
 // end-to-end through run: with hideOutputOnSuccess=true, a successful command
 // produces no output while a failing command does.
@@ -440,7 +496,7 @@ func Test_configuredOper_run_cancellation(t *testing.T) {
 func Test_configuredOper_New(t *testing.T) {
 	t.Run("it should return incrementConfigError if increment is true and no args contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", true, "", false, false)
 		if gotErr == nil {
 			t.Fatal("expected to get error, got nil")
 		}
@@ -459,7 +515,7 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if increment is true and one argument is 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "INC"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", true, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
@@ -467,7 +523,7 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if increment is true and one argument contains 'INC'", func(t *testing.T) {
 		args := []string{"test", "abc", "another-argument/INC"}
-		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, "", "", true, "", false, false)
+		_, gotErr := New(0, 0, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", true, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
@@ -477,7 +533,7 @@ func Test_configuredOper_New(t *testing.T) {
 		am := 1
 		workers := 2
 		args := []string{"test", "abc"}
-		_, gotErr := New(am, workers, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
+		_, gotErr := New(am, workers, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", false, "", false, false)
 		if gotErr == nil {
 			t.Fatal("expected to get error, got nil")
 		}
@@ -491,14 +547,14 @@ func Test_configuredOper_New(t *testing.T) {
 
 	t.Run("it should not return an error if the number of workers is lower than the number of times to repeat the command", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(2, 1, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
+		_, gotErr := New(2, 1, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", false, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
 	})
 	t.Run("it should not return an error if the number of workers is equal to the number of times to repeat the command", func(t *testing.T) {
 		args := []string{"test", "abc"}
-		_, gotErr := New(2, 2, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, false)
+		_, gotErr := New(2, 2, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", false, "", false, false)
 		if gotErr != nil {
 			t.Fatalf("expected nil, got: %v", gotErr)
 		}
@@ -509,7 +565,7 @@ func Test_configuredOper_New(t *testing.T) {
 	t.Run("it should wire the hideOutputOnSuccess argument into the returned struct", func(t *testing.T) {
 		for _, want := range []bool{true, false} {
 			args := []string{"true"}
-			c, gotErr := New(1, 1, args, output.HIDDEN, "testing", output.HIDDEN, "", "", false, "", false, want)
+			c, gotErr := New(1, 1, args, output.HIDDEN, "testing", output.HIDDEN, outputFormatV1, "", "", false, "", false, want)
 			if gotErr != nil {
 				t.Fatalf("expected nil, got: %v", gotErr)
 			}

--- a/configured_oper_work.go
+++ b/configured_oper_work.go
@@ -16,6 +16,29 @@ import (
 	"github.com/baalimago/repeater/pkg/filetools"
 )
 
+type outputStream string
+
+const (
+	stdoutStream outputStream = "stdout"
+	stderrStream outputStream = "stderr"
+)
+
+type outputRecorder struct {
+	res    *Result
+	stream outputStream
+}
+
+func (o outputRecorder) Write(p []byte) (n int, err error) {
+	event := OutputEvent{At: time.Now().UTC(), Text: string(p)}
+	if o.stream == stdoutStream {
+		o.res.Stdout = append(o.res.Stdout, event)
+	} else {
+		o.res.Stderr = append(o.res.Stderr, event)
+	}
+	o.res.Output += string(p)
+	return len(p), nil
+}
+
 func (c *configuredOper) replaceIncrement(args []string, i int) []string {
 	if c.increment {
 		var newArgs []string
@@ -37,13 +60,14 @@ func (c *configuredOper) doWork(ctx context.Context, workerID, taskIdx int, tee 
 	}
 	args := c.replaceIncrement(c.args[1:], taskIdx)
 	do := exec.CommandContext(ctx, c.args[0], args...)
+	stdoutWriter := io.Writer(outputRecorder{res: &res, stream: stdoutStream})
+	stderrWriter := io.Writer(outputRecorder{res: &res, stream: stderrStream})
 	if tee != nil {
-		allOut := io.MultiWriter(&res, tee)
-		do.Stdout = allOut
-		do.Stderr = allOut
+		do.Stdout = io.MultiWriter(stdoutWriter, tee)
+		do.Stderr = io.MultiWriter(stderrWriter, tee)
 	} else {
-		do.Stdout = &res
-		do.Stderr = &res
+		do.Stdout = stdoutWriter
+		do.Stderr = stderrWriter
 	}
 	t0 := time.Now()
 	err := do.Run()

--- a/configured_oper_work.go
+++ b/configured_oper_work.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,13 +30,13 @@ func (c *configuredOper) replaceIncrement(args []string, i int) []string {
 	return args
 }
 
-func (c *configuredOper) doWork(workerID, taskIdx int, tee io.Writer) Result {
+func (c *configuredOper) doWork(ctx context.Context, workerID, taskIdx int, tee io.Writer) Result {
 	res := Result{
 		WorkerID: workerID,
 		Idx:      taskIdx,
 	}
 	args := c.replaceIncrement(c.args[1:], taskIdx)
-	do := exec.Command(c.args[0], args...)
+	do := exec.CommandContext(ctx, c.args[0], args...)
 	if tee != nil {
 		allOut := io.MultiWriter(&res, tee)
 		do.Stdout = allOut
@@ -51,7 +52,11 @@ func (c *configuredOper) doWork(workerID, taskIdx int, tee io.Writer) Result {
 	res.RuntimeHumanReadable = timeSpent.String()
 	if err != nil {
 		res.Output = err.Error() + res.Output
-		res.IsError = true
+		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			res.IsCancelled = true
+		} else {
+			res.IsError = true
+		}
 	}
 	return res
 }
@@ -70,6 +75,9 @@ func (c *configuredOper) setupWorkers(workCtx context.Context, workChan chan int
 			for {
 				select {
 				case <-workCtx.Done():
+					c.workPlanMu.Lock()
+					c.wasCancelled = true
+					c.workPlanMu.Unlock()
 					c.workerWg.Done()
 					return
 				case taskIdx := <-workChan:
@@ -86,7 +94,12 @@ func (c *configuredOper) setupWorkers(workCtx context.Context, workChan chan int
 					}
 					c.amIdleWorkers--
 					c.workPlanMu.Unlock()
-					res := c.doWork(workerID, taskIdx, tmpFile)
+					res := c.doWork(workCtx, workerID, taskIdx, tmpFile)
+					if workCtx.Err() != nil {
+						c.workPlanMu.Lock()
+						c.wasCancelled = true
+						c.workPlanMu.Unlock()
+					}
 					c.workPlanMu.Lock()
 					c.amIdleWorkers++
 					if !res.IsError {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	progressFlag        = flag.String("progress", "STDOUT", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
 	progressFormatFlag  = flag.String("progressFormat", DefaultProgressFormat, "Set the format for the output where 1st arg is the iteration and 2d arg is the amount of runs, 3d total, 4th start, 5th countdown (human-readable, e.g. '1d 2h 3m 4s'), 6th est completion time.")
 	outputFlag          = flag.String("output", "HIDDEN", "Options are: ['HIDDEN', 'FILE', 'STDOUT', 'BOTH']")
+	outputFormatFlag    = flag.String("outputFormat", outputFormatV1, "Options are: ['v1', 'v2']")
 	fileFlag            = flag.String("file", "", "Path to the file where the report will be saved, configure file conflicts automatically with 'fileMode'")
 	fileModeFlag        = flag.String("fileMode", "", "Configure how the report file should be treated. If a file exists, and this option isn't set, user will be queried. Options are: ['t'runcate, 'a'ppend] ")
 	statisticsFlag      = flag.Bool("statistics", true, "Set to true if you don't wish to see statistics of the repeated command.")
@@ -50,6 +51,7 @@ func main() {
 		args, output.New(progressFlag),
 		*progressFormatFlag,
 		output.New(outputFlag),
+		*outputFormatFlag,
 		*fileFlag,
 		*fileModeFlag,
 		*incrementFlag,

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	isDone := make(chan statistics)
+	wasCancelled := false
 	go func() {
 		isDone <- c.run(ctx)
 	}()
@@ -100,20 +101,18 @@ func main() {
 		printOK("The repeat, has been done. Farewell.\n")
 		os.Exit(0)
 	case <-signalChannel:
+		wasCancelled = true
 	}
 	ctxCancel()
 	select {
 	case stats := <-isDone:
+		if wasCancelled {
+			stats.cancelled = true
+		}
 		if *statisticsFlag {
 			fmt.Printf("%s\n", &stats)
 		}
 		printOK("graceful shutdown complete")
-	case <-signalChannel:
-		printErr("aborting graceful shutdown")
-	case <-isDone:
-		if ctx.Err() != nil {
-			printOK("graceful shutdown complete")
-		}
 	case <-signalChannel:
 		printErr("aborting graceful shutdown")
 	}

--- a/statistics.go
+++ b/statistics.go
@@ -6,12 +6,19 @@ import (
 	"time"
 )
 
+type OutputEvent struct {
+	At   time.Time
+	Text string
+}
+
 type Result struct {
 	WorkerID             int           `json:"workerID"`
 	Idx                  int           `json:"taskIdx"`
 	Runtime              time.Duration `json:"runtime"`
 	RuntimeHumanReadable string        `json:"runtimeHumanReadable"`
 	Output               string        `json:"output"`
+	Stdout               []OutputEvent `json:"stdout,omitempty"`
+	Stderr               []OutputEvent `json:"stderr,omitempty"`
 	IsError              bool          `json:"isError"`
 	IsCancelled          bool          `json:"isCancelled"`
 }

--- a/statistics.go
+++ b/statistics.go
@@ -13,18 +13,22 @@ type Result struct {
 	RuntimeHumanReadable string        `json:"runtimeHumanReadable"`
 	Output               string        `json:"output"`
 	IsError              bool          `json:"isError"`
+	IsCancelled          bool          `json:"isCancelled"`
 }
 
 type statistics struct {
-	am      int
-	amFails int
-	max     Result
-	min     Result
-	total   time.Duration
-	runtime time.Duration
-	average time.Duration
-	stdDev  time.Duration
-	Results []Result `json:"results"`
+	am          int
+	amDone      int
+	amFails     int
+	amCancelled int
+	cancelled   bool
+	max         Result
+	min         Result
+	total       time.Duration
+	runtime     time.Duration
+	average     time.Duration
+	stdDev      time.Duration
+	Results     []Result `json:"results"`
 }
 
 // Write implements io.Writer to get the output of the command for
@@ -43,8 +47,13 @@ func (c *configuredOper) calcStats() statistics {
 	minDur := time.Duration(9223372036854775807)
 	maxDur := time.Duration(-9223372036854775808)
 	amFails := 0
+	amCancelled := 0
 	var min, max Result
 	for _, r := range c.results {
+		if r.IsCancelled {
+			amCancelled++
+			continue
+		}
 		if r.IsError {
 			amFails++
 			continue
@@ -68,28 +77,35 @@ func (c *configuredOper) calcStats() statistics {
 	variance := varSum / float64(n)
 	stdDeviation := time.Duration(int64(math.Sqrt(variance)))
 	return statistics{
-		am:      c.am,
-		amFails: amFails,
-		runtime: c.runtime,
-		min:     min,
-		max:     max,
-		total:   tot,
-		average: time.Duration(avr),
-		stdDev:  stdDeviation,
-		Results: c.results,
+		am:          c.am,
+		amDone:      n,
+		amFails:     amFails,
+		amCancelled: amCancelled,
+		cancelled:   c.wasCancelled,
+		runtime:     c.runtime,
+		min:         min,
+		max:         max,
+		total:       tot,
+		average:     time.Duration(avr),
+		stdDev:      stdDeviation,
+		Results:     c.results,
 	}
 }
 
 func (s *statistics) String() string {
+	state := ""
+	if s.cancelled {
+		state = " (cancelled)"
+	}
 	return fmt.Sprintf(`
 == Statistics ==
-Amount of repitions: %v, amount of failures: %v,
+Amount of repitions: %v, completed: %v, amount of failures: %v, amount of cancelled: %v%s,
 The following is calculated on successful attempts:
   Runtime: %s, Total routine work time: %v,
   Average time per task: %v, Std deviation: %v
   Max time, index: %v, time: %v
   Min time, index: %v, time: %v`,
-		s.am, s.amFails,
+		s.am, s.amDone, s.amFails, s.amCancelled, state,
 		s.runtime, s.total,
 		s.average, s.stdDev,
 		s.max.Idx, s.max.Runtime,

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"math"
+	"strings"
 	"testing"
 	"time"
 )
@@ -63,5 +64,38 @@ func TestCalcStats(t *testing.T) {
 		math.Pow(float64(30*time.Second-expectedAverage), 2)) / 3))
 	if stats.stdDev != expectedStdDev {
 		t.Errorf("Expected standard deviation: %v, got: %v", expectedStdDev, stats.stdDev)
+	}
+}
+
+func TestCalcStats_separatesFailuresFromCancelled(t *testing.T) {
+	results := []Result{
+		{Idx: 1, Runtime: 10 * time.Second},
+		{Idx: 2, Runtime: 20 * time.Second, IsError: true},
+		{Idx: 3, Runtime: 30 * time.Second, IsCancelled: true},
+	}
+	c := configuredOper{am: 3, results: results}
+	stats := c.calcStats()
+	if stats.amFails != 1 {
+		t.Fatalf("expected 1 failure, got %d", stats.amFails)
+	}
+	if stats.amCancelled != 1 {
+		t.Fatalf("expected 1 cancelled, got %d", stats.amCancelled)
+	}
+	if stats.amDone != 3 {
+		t.Fatalf("expected 3 completed, got %d", stats.amDone)
+	}
+}
+
+func TestStatisticsString_reportsCompletedAndCancelled(t *testing.T) {
+	stats := statistics{am: 3, amDone: 1, amFails: 1, amCancelled: 1, cancelled: true}
+	got := stats.String()
+	if !strings.Contains(got, "completed: 1") {
+		t.Fatalf("expected completed count in statistics string, got: %s", got)
+	}
+	if !strings.Contains(got, "amount of cancelled: 1") {
+		t.Fatalf("expected cancelled count in statistics string, got: %s", got)
+	}
+	if !strings.Contains(got, "(cancelled)") {
+		t.Fatalf("expected cancelled marker in statistics string, got: %s", got)
 	}
 }


### PR DESCRIPTION
Changes:
* Added AGENTS.md
* Added new output format which splits stdout and stderr (but has timestamp for sorting)
  * Configure with `-outputFormat v2`, defaults to v1 (original)
* Prints statistics on context cancels as well